### PR TITLE
Integer to BigInt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:2.5.8
+
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN mkdir /preflight
+
+WORKDIR /preflight
+
+ADD .ruby-version /preflight/.ruby-version
+ADD Gemfile /preflight/Gemfile
+ADD Gemfile.lock /preflight/Gemfile.lock
+
+RUN bundle install
+ADD . /preflight

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,9 @@
 development:
   adapter: postgresql
-  database: preflight-dev
+  host: db
+  database: <%= ENV.fetch("POSTGRES_DB") %>
+  username: <%= ENV.fetch("POSTGRES_USER") %>
+  password: <%= ENV.fetch("POSTGRES_PASSWORD") %>
   pool: 10
   timeout: 5000
 

--- a/db/migrate/20241106203538_change_applied_checklist_pull_request_id_integer_to_big_int.rb
+++ b/db/migrate/20241106203538_change_applied_checklist_pull_request_id_integer_to_big_int.rb
@@ -1,0 +1,9 @@
+class ChangeAppliedChecklistPullRequestIdIntegerToBigInt < ActiveRecord::Migration[5.2]
+  def up
+    change_column :applied_checklists, :github_pull_request_id, :bigint
+  end
+
+  def down
+    change_column :applied_checklists, :github_pull_request_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,110 +10,101 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181125230625) do
+ActiveRecord::Schema.define(version: 2024_11_06_203538) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "applied_checklists", force: :cascade do |t|
-    t.integer  "checklist_id",           null: false
-    t.integer  "github_pull_request_id", null: false
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+  create_table "applied_checklists", id: :serial, force: :cascade do |t|
+    t.integer "checklist_id", null: false
+    t.bigint "github_pull_request_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["github_pull_request_id", "checklist_id"], name: "one_checklist_application_per_pull", unique: true
   end
 
-  add_index "applied_checklists", ["checklist_id"], name: "index_applied_checklists_on_checklist_id", using: :btree
-  add_index "applied_checklists", ["github_pull_request_id", "checklist_id"], name: "one_checklist_application_per_pull", unique: true, using: :btree
-
-  create_table "checklist_items", force: :cascade do |t|
-    t.string   "name",          null: false
-    t.integer  "checklist_id",  null: false
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
-    t.integer  "created_by_id", null: false
+  create_table "checklist_items", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "checklist_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "created_by_id", null: false
   end
 
-  create_table "checklists", force: :cascade do |t|
-    t.string   "name",                       null: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.integer  "created_by_id",              null: false
-    t.integer  "github_repository_id",       null: false
-    t.string   "with_file_matching_pattern"
-    t.integer  "last_updated_by_id",         null: false
+  create_table "checklists", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "created_by_id", null: false
+    t.integer "github_repository_id", null: false
+    t.string "with_file_matching_pattern"
+    t.integer "last_updated_by_id", null: false
+    t.index ["github_repository_id"], name: "index_checklists_on_github_repository_id"
   end
 
-  add_index "checklists", ["github_repository_id"], name: "index_checklists_on_github_repository_id", using: :btree
-
-  create_table "delayed_jobs", force: :cascade do |t|
-    t.integer  "priority",   default: 0, null: false
-    t.integer  "attempts",   default: 0, null: false
-    t.text     "handler",                null: false
-    t.text     "last_error"
+  create_table "delayed_jobs", id: :serial, force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
-    t.string   "locked_by"
-    t.string   "queue"
+    t.string "locked_by"
+    t.string "queue"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
-
-  create_table "github_repositories", force: :cascade do |t|
-    t.integer  "github_id",         null: false
-    t.string   "github_full_name",  null: false
-    t.string   "github_owner_type", null: false
-    t.string   "github_url",        null: false
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+  create_table "github_repositories", id: :serial, force: :cascade do |t|
+    t.integer "github_id", null: false
+    t.string "github_full_name", null: false
+    t.string "github_owner_type", null: false
+    t.string "github_url", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["github_id"], name: "index_github_repositories_on_github_id", unique: true
   end
 
-  add_index "github_repositories", ["github_id"], name: "index_github_repositories_on_github_id", unique: true, using: :btree
-
-  create_table "github_webhooks", force: :cascade do |t|
-    t.integer  "github_id",            null: false
-    t.integer  "github_repository_id", null: false
-    t.integer  "created_by_id",        null: false
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
+  create_table "github_webhooks", id: :serial, force: :cascade do |t|
+    t.integer "github_id", null: false
+    t.integer "github_repository_id", null: false
+    t.integer "created_by_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.datetime "hook_deleted_at"
+    t.index ["github_id"], name: "index_github_webhooks_on_github_id"
   end
 
-  add_index "github_webhooks", ["github_id"], name: "index_github_webhooks_on_github_id", using: :btree
-  add_index "github_webhooks", ["github_repository_id"], name: "index_github_webhooks_on_github_repository_id", unique: true, using: :btree
-
-  create_table "identities", force: :cascade do |t|
-    t.string   "provider",      null: false
-    t.integer  "user_id",       null: false
-    t.string   "uid",           null: false
-    t.text     "omniauth_data", null: false
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+  create_table "identities", id: :serial, force: :cascade do |t|
+    t.string "provider", null: false
+    t.integer "user_id", null: false
+    t.string "uid", null: false
+    t.text "omniauth_data", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["uid", "provider"], name: "index_identities_on_uid_and_provider", unique: true
+    t.index ["user_id", "provider"], name: "index_identities_on_user_id_and_provider", unique: true
   end
 
-  add_index "identities", ["uid", "provider"], name: "index_identities_on_uid_and_provider", unique: true, using: :btree
-  add_index "identities", ["user_id", "provider"], name: "index_identities_on_user_id_and_provider", unique: true, using: :btree
-
-  create_table "users", force: :cascade do |t|
-    t.string   "email",                            default: "",    null: false
-    t.string   "encrypted_password",               default: "",    null: false
-    t.string   "reset_password_token"
+  create_table "users", id: :serial, force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                    default: 0,     null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.inet     "current_sign_in_ip"
-    t.inet     "last_sign_in_ip"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "admin",                            default: false, null: false
-    t.text     "accessible_github_repository_ids", default: [],                 array: true
+    t.boolean "admin", default: false, null: false
+    t.text "accessible_github_repository_ids", default: [], array: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
-
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+services:
+  db:
+    image: postgres:14.12
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER:
+      POSTGRES_PASSWORD:
+      POSTGRES_DB:
+
+
+  web:
+    build: .
+    entrypoint: ./docker-web-entrypoint.sh
+    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    volumes:
+      - .:/preflight
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+    env_file:
+      - .env

--- a/docker-web-entrypoint.sh
+++ b/docker-web-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ -f tmp/pids/server.pid ]; then
+  rm tmp/pids/server.pid
+fi
+
+exec bundle exec "$@"


### PR DESCRIPTION
Since days ago we started to see Preflight no more refreshing Genius PR within checklists (or applied checklists). It's caused by `applied_checklists.github_pull_request_id` column bigger than column size limit. Then, this PR converts the column type from Integer (Int4) to BigInt (Int8).

We are also including a Docker script to make life easier for devs whenever we need to make any work on this Repo.

#### Indexes removed on `schema.rb`

- `index_github_webhooks_on_github_repository_id`
- `index_applied_checklists_on_checklist_id`

Since the column has the `belongs_to` association, looks like `rake db:migrate` ignores the explicit index.

