### PR TITLE
Add preflight checklist for dataclips skill updates

### DIFF
--- a/db/migrate/20260207000000_add_dataclips_skill_checklist.rb
+++ b/db/migrate/20260207000000_add_dataclips_skill_checklist.rb
@@ -1,0 +1,30 @@
+class AddDataclipsSkillChecklist < ActiveRecord::Migration[7.2]
+  def up
+    repo = GithubRepository.find_by!(github_full_name: "Genius/Rap-Genius")
+    admin = User.find_by!(admin: true)
+
+    checklist = Checklist.create!(
+      name: "Dataclips Skill Update",
+      github_repository: repo,
+      created_by: admin,
+      last_updated_by: admin,
+      with_file_matching_pattern: "db/development_structure\\.sql",
+    )
+
+    ChecklistItem.create!(
+      checklist: checklist,
+      name: "If `db/development_structure.sql` has changed, check with the product team to confirm whether the dataclips skill needs to be updated.",
+      created_by: admin,
+    )
+  end
+
+  def down
+    repo = GithubRepository.find_by(github_full_name: "Genius/Rap-Genius")
+    return unless repo
+
+    Checklist.where(
+      github_repository: repo,
+      name: "Dataclips Skill Update",
+    ).destroy_all
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a data migration that creates a new preflight checklist for the `Genius/Rap-Genius` repo
- When `db/development_structure.sql` changes in a PR, a checklist item is added prompting the developer to check with the product team on whether the dataclips skill needs to be updated
- Uses the `with_file_matching_pattern` regex to scope the checklist to only PRs that touch the DB structure file

## Test plan

- [ ] Run `bin/rails db:migrate` in production/staging to apply the migration
- [ ] Open a PR in `Genius/Rap-Genius` that modifies `db/development_structure.sql` and verify the checklist appears
- [ ] Open a PR that does NOT touch `db/development_structure.sql` and verify the checklist is not added

🤖 Generated with [Claude Code](https://claude.com/claude-code)