### PR TITLE
Use head sha instead of merge sha

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -34,7 +34,7 @@ class Users::OmniauthCallbacksController < ApplicationController
     login = omniauth.info.nickname
 
     unless client.team_member?(ENV.fetch('GITHUB_TEAM_ID'), login)
-      render :status => :forbidden, :text => "Sorry!"
+      render :status => :forbidden, :plain => "Sorry!"
     end
   end
 

--- a/app/jobs/update_pr_status_job.rb
+++ b/app/jobs/update_pr_status_job.rb
@@ -5,7 +5,7 @@ class UpdatePrStatusJob < ApplicationJob
     client = GithubClient.for_installation(installation_id)
     pr = client.pull_request(repo.github_full_name, pr_number)
 
-    merge_sha = pr[:merge_commit_sha]
+    head_sha = pr.dig(:head, :sha)
     body = pr[:body]
 
     begin
@@ -23,6 +23,6 @@ class UpdatePrStatusJob < ApplicationJob
       status = :error
     end
 
-    client.create_status(repo.github_full_name, merge_sha, status, context: I18n.t('check_name'), description: desc)
+    client.create_status(repo.github_full_name, head_sha, status, context: I18n.t('check_name'), description: desc)
   end
 end


### PR DESCRIPTION
Hopefully fixes GEN-6586

2 changes:

1. [Fix 500 when trying to render an error](https://github.com/Genius/preflight/commit/98bdd97f902b2ee1a80a5a566d7427221e40563a) - Rails 5 deprecated responding as text in favor of `:plain`. I missed this while upgrading in #5
2. [Apply status to the head sha, not the merge sha](https://github.com/Genius/preflight/commit/382da4c5023ae0e44077eedcbee6e38e7ceb6291) - GitHub periodically recomputes merge shas so they are less stable than the last commit on the branch. This should fix statuses disappearing after being left alone for a while.

## Test Plan

I confirmed the status checks support is still working on a dev app. Can't really tell if GEN-6586 will be solved though without relying on it in the real world :(